### PR TITLE
Namespace deliminator support

### DIFF
--- a/lib/Pod/ProjectDocs.pm
+++ b/lib/Pod/ProjectDocs.pm
@@ -270,6 +270,11 @@ if you set this parameter as regex, the file matches this regex won't be checked
     ...other parameters
   );
 
+=item namespace_deliminator
+
+string used for deliminating namespaces (e.g. deliminator '::' will cause File::Spec.
+default is '-'.
+
 =back
 
 =head1 pod2projdocs

--- a/lib/Pod/ProjectDocs.pm
+++ b/lib/Pod/ProjectDocs.pm
@@ -270,9 +270,9 @@ if you set this parameter as regex, the file matches this regex won't be checked
     ...other parameters
   );
 
-=item namespace_deliminator
+=item namespace_delimiter
 
-string used for deliminating namespaces (e.g. deliminator '::' will cause File::Spec.
+string used for delimiting namespaces (e.g. delimiter '::' will cause File::Spec).
 default is '-'.
 
 =back

--- a/lib/Pod/ProjectDocs/Config.pm
+++ b/lib/Pod/ProjectDocs/Config.pm
@@ -17,14 +17,14 @@ __PACKAGE__->mk_accessors(qw/
     forcegen
     lang
     except
-    namespace_deliminator
+    namespace_delimiter
 /);
 
-Readonly my $DEFAULT_TITLE                 => qq/MyProject's Libraries/;
-Readonly my $DEFAULT_DESC                  => qq/manuals and libraries/;
-Readonly my $DEFAULT_CHARSET               => qq/UTF-8/;
-Readonly my $DEFAULT_LANG                  => qq/en/;
-Readonly my $DEFAULT_NAMESPACE_DELIMINATOR => qq/-/;
+Readonly my $DEFAULT_TITLE               => qq/MyProject's Libraries/;
+Readonly my $DEFAULT_DESC                => qq/manuals and libraries/;
+Readonly my $DEFAULT_CHARSET             => qq/UTF-8/;
+Readonly my $DEFAULT_LANG                => qq/en/;
+Readonly my $DEFAULT_NAMESPACE_DELIMITER => qq/-/;
 
 sub new {
     my $class = shift;
@@ -35,17 +35,17 @@ sub new {
 
 sub _init {
     my($self, %args) = @_;
-    $self->title                ( $args{title}                 || $DEFAULT_TITLE                 );
-    $self->desc                 ( $args{desc}                  || $DEFAULT_DESC                  );
-    $self->charset              ( $args{charset}               || $DEFAULT_CHARSET               );
-    $self->lang                 ( $args{lang}                  || $DEFAULT_LANG                  );
-    $self->namespace_deliminator( $args{namespace_deliminator} || $DEFAULT_NAMESPACE_DELIMINATOR );
-    $self->verbose              ( $args{verbose}                                                 );
-    $self->index                ( $args{index}                                                   );
-    $self->outroot              ( $args{outroot}                                                 );
-    $self->libroot              ( $args{libroot}                                                 );
-    $self->forcegen             ( $args{forcegen}                                                );
-    $self->except               ( $args{except}                                                  );
+    $self->title              ( $args{title}               || $DEFAULT_TITLE               );
+    $self->desc               ( $args{desc}                || $DEFAULT_DESC                );
+    $self->charset            ( $args{charset}             || $DEFAULT_CHARSET             );
+    $self->lang               ( $args{lang}                || $DEFAULT_LANG                );
+    $self->namespace_delimiter( $args{namespace_delimiter} || $DEFAULT_NAMESPACE_DELIMITER );
+    $self->verbose            ( $args{verbose}                                             );
+    $self->index              ( $args{index}                                               );
+    $self->outroot            ( $args{outroot}                                             );
+    $self->libroot            ( $args{libroot}                                             );
+    $self->forcegen           ( $args{forcegen}                                            );
+    $self->except             ( $args{except}                                              );
 }
 
 1;

--- a/lib/Pod/ProjectDocs/Config.pm
+++ b/lib/Pod/ProjectDocs/Config.pm
@@ -17,12 +17,14 @@ __PACKAGE__->mk_accessors(qw/
     forcegen
     lang
     except
+    namespace_deliminator
 /);
 
-Readonly my $DEFAULT_TITLE   => qq/MyProject's Libraries/;
-Readonly my $DEFAULT_DESC    => qq/manuals and libraries/;
-Readonly my $DEFAULT_CHARSET => qq/UTF-8/;
-Readonly my $DEFAULT_LANG    => qq/en/;
+Readonly my $DEFAULT_TITLE                 => qq/MyProject's Libraries/;
+Readonly my $DEFAULT_DESC                  => qq/manuals and libraries/;
+Readonly my $DEFAULT_CHARSET               => qq/UTF-8/;
+Readonly my $DEFAULT_LANG                  => qq/en/;
+Readonly my $DEFAULT_NAMESPACE_DELIMINATOR => qq/-/;
 
 sub new {
     my $class = shift;
@@ -33,16 +35,17 @@ sub new {
 
 sub _init {
     my($self, %args) = @_;
-    $self->title   ( $args{title}   || $DEFAULT_TITLE   );
-    $self->desc    ( $args{desc}    || $DEFAULT_DESC    );
-    $self->charset ( $args{charset} || $DEFAULT_CHARSET );
-    $self->lang    ( $args{lang}    || $DEFAULT_LANG    );
-    $self->verbose ( $args{verbose}                     );
-    $self->index   ( $args{index}                       );
-    $self->outroot ( $args{outroot}                     );
-    $self->libroot ( $args{libroot}                     );
-    $self->forcegen( $args{forcegen}                    );
-    $self->except  ( $args{except}                      );
+    $self->title                ( $args{title}                 || $DEFAULT_TITLE                 );
+    $self->desc                 ( $args{desc}                  || $DEFAULT_DESC                  );
+    $self->charset              ( $args{charset}               || $DEFAULT_CHARSET               );
+    $self->lang                 ( $args{lang}                  || $DEFAULT_LANG                  );
+    $self->namespace_deliminator( $args{namespace_deliminator} || $DEFAULT_NAMESPACE_DELIMINATOR );
+    $self->verbose              ( $args{verbose}                                                 );
+    $self->index                ( $args{index}                                                   );
+    $self->outroot              ( $args{outroot}                                                 );
+    $self->libroot              ( $args{libroot}                                                 );
+    $self->forcegen             ( $args{forcegen}                                                );
+    $self->except               ( $args{except}                                                  );
 }
 
 1;

--- a/lib/Pod/ProjectDocs/Doc.pm
+++ b/lib/Pod/ProjectDocs/Doc.pm
@@ -29,7 +29,7 @@ sub _set_relpath {
     $self->_check_dir($reldir, File::Spec->catdir($outroot, "src"));
     my $relpath = File::Spec->catdir($reldir, $name);
     $relpath =~ s:\\:/:g if $^O eq 'MSWin32';
-    $self->name( join $self->config->namespace_deliminator, File::Spec->splitdir($relpath) );
+    $self->name( join $self->config->namespace_delimiter, File::Spec->splitdir($relpath) );
     $self->relpath($relpath.".".$suffix.".html");
 }
 

--- a/lib/Pod/ProjectDocs/Doc.pm
+++ b/lib/Pod/ProjectDocs/Doc.pm
@@ -6,7 +6,7 @@ use File::Basename;
 use File::Spec;
 use File::Copy;
 
-__PACKAGE__->mk_accessors(qw/origin suffix origin_root title/);
+__PACKAGE__->mk_accessors(qw/origin suffix origin_root title namespace_deliminator/);
 __PACKAGE__->data( do{ local $/; <DATA> } );
 
 sub _init {
@@ -29,7 +29,7 @@ sub _set_relpath {
     $self->_check_dir($reldir, File::Spec->catdir($outroot, "src"));
     my $relpath = File::Spec->catdir($reldir, $name);
     $relpath =~ s:\\:/:g if $^O eq 'MSWin32';
-    $self->name( join "-", File::Spec->splitdir($relpath) );
+    $self->name( join $self->config->namespace_deliminator, File::Spec->splitdir($relpath) );
     $self->relpath($relpath.".".$suffix.".html");
 }
 

--- a/lib/Pod/ProjectDocs/Doc.pm
+++ b/lib/Pod/ProjectDocs/Doc.pm
@@ -6,7 +6,7 @@ use File::Basename;
 use File::Spec;
 use File::Copy;
 
-__PACKAGE__->mk_accessors(qw/origin suffix origin_root title namespace_deliminator/);
+__PACKAGE__->mk_accessors(qw/origin suffix origin_root title/);
 __PACKAGE__->data( do{ local $/; <DATA> } );
 
 sub _init {


### PR DESCRIPTION
As some people may find disturbing to see Pod-ProjectDocs labels in index page and other places, I added support for customizing '-' deliminator, it can be used in order to get labels in  Pod::ProjectDocs form. The default behavior is unchanged.
