### PR TITLE
Add sorting for JSON string generation to generate stable structures.

### DIFF
--- a/lib/Pod/ProjectDocs.pm
+++ b/lib/Pod/ProjectDocs.pm
@@ -163,7 +163,7 @@ sub get_managers_json {
             push @$records, $record;
         }
     }
-    return $js->encode($records);
+    return $js->canonical()->encode($records);
 }
 
 sub _croak {


### PR DESCRIPTION
Currently the generated JSON strings are not stable, they may change in sorting with every run. This is not so good if you want to checkin the generated documentation into a version control system as it changes every time. This patch enables sorting on the JSON output so that it generates a string that is stable over time and thus does not create new commits in the documentation tree if nothing changed in the source tree.
